### PR TITLE
Add HMAC-SHA256 snippet as a complex circuit example

### DIFF
--- a/docs/snippets/hmac-sha256/hmac-sha256.test.ts
+++ b/docs/snippets/hmac-sha256/hmac-sha256.test.ts
@@ -1,102 +1,102 @@
-import { describe, expect, it } from 'vitest';
-import { Bytes } from 'o1js';
-import { HMAC_SHA256 } from './hmac-sha256';
+import { describe, expect, it } from "vitest";
+import { Bytes } from "o1js";
+import { HMAC_SHA256 } from "./hmac-sha256";
 
-describe('HMAC-SHA256 RFC 4231 Test Vectors', () => {
+describe("HMAC-SHA256 RFC 4231 Test Vectors", () => {
   // Test Case 1 - Basic test case with key length < block size
-  it('should pass RFC 4231 Test Case 1', () => {
-    const key = Bytes.fromHex('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b');
-    const data = Bytes.fromString('Hi There');
+  it("should pass RFC 4231 Test Case 1", () => {
+    const key = Bytes.fromHex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    const data = Bytes.fromString("Hi There");
 
     const ourHmac = HMAC_SHA256.compute(key, data);
     const expectedHmac =
-      'b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7';
+      "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7";
 
     expect(ourHmac.toHex()).toBe(expectedHmac);
   });
 
   // Test Case 2 - Test with key and data that is the ASCII string "what do ya want for nothing?"
-  it('should pass RFC 4231 Test Case 2', () => {
-    const key = Bytes.fromString('Jefe');
-    const data = Bytes.fromString('what do ya want for nothing?');
+  it("should pass RFC 4231 Test Case 2", () => {
+    const key = Bytes.fromString("Jefe");
+    const data = Bytes.fromString("what do ya want for nothing?");
 
     const ourHmac = HMAC_SHA256.compute(key, data);
     const expectedHmac =
-      '5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843';
+      "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843";
 
     expect(ourHmac.toHex()).toBe(expectedHmac);
   });
 
   // Test Case 3 - Test with key and data that are long hex strings
-  it('should pass RFC 4231 Test Case 3', () => {
-    const key = Bytes.fromHex('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  it("should pass RFC 4231 Test Case 3", () => {
+    const key = Bytes.fromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     const data = Bytes.fromHex(
-      'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+      "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
     );
 
     const ourHmac = HMAC_SHA256.compute(key, data);
     const expectedHmac =
-      '773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe';
+      "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe";
 
     expect(ourHmac.toHex()).toBe(expectedHmac);
   });
 
   // Test Case 4 - Test with key and data that are long hex strings
-  it('should pass RFC 4231 Test Case 4', () => {
+  it("should pass RFC 4231 Test Case 4", () => {
     const key = Bytes.fromHex(
-      '0102030405060708090a0b0c0d0e0f10111213141516171819'
+      "0102030405060708090a0b0c0d0e0f10111213141516171819"
     );
     const data = Bytes.fromHex(
-      'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'
+      "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
     );
 
     const ourHmac = HMAC_SHA256.compute(key, data);
     const expectedHmac =
-      '82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b';
+      "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b";
 
     expect(ourHmac.toHex()).toBe(expectedHmac);
   });
 
   // Test Case 5 - Test with truncation to 128 bits
-  it('should pass RFC 4231 Test Case 5 (without truncation)', () => {
-    const key = Bytes.fromHex('0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c');
-    const data = Bytes.fromString('Test With Truncation');
+  it("should pass RFC 4231 Test Case 5 (without truncation)", () => {
+    const key = Bytes.fromHex("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c");
+    const data = Bytes.fromString("Test With Truncation");
 
     const ourHmac = HMAC_SHA256.compute(key, data);
     const expectedHmac =
-      'a3b6167473100ee06e0c796c2955552bfa6f7c0a6a8aef8b93f860aab0cd20c5';
+      "a3b6167473100ee06e0c796c2955552bfa6f7c0a6a8aef8b93f860aab0cd20c5";
 
     expect(ourHmac.toHex()).toBe(expectedHmac);
   });
 
   // Test Case 6 - Test with key larger than block size
-  it('should pass RFC 4231 Test Case 6', () => {
+  it("should pass RFC 4231 Test Case 6", () => {
     const key = Bytes.fromHex(
-      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     );
     const data = Bytes.fromString(
-      'Test Using Larger Than Block-Size Key - Hash Key First'
+      "Test Using Larger Than Block-Size Key - Hash Key First"
     );
 
     const ourHmac = HMAC_SHA256.compute(key, data);
     const expectedHmac =
-      '60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54';
+      "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54";
 
     expect(ourHmac.toHex()).toBe(expectedHmac);
   });
 
   // Test Case 7 - Test with key and data larger than block size
-  it('should pass RFC 4231 Test Case 7', () => {
+  it("should pass RFC 4231 Test Case 7", () => {
     const key = Bytes.fromHex(
-      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     );
     const data = Bytes.fromString(
-      'This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.'
+      "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm."
     );
 
     const ourHmac = HMAC_SHA256.compute(key, data);
     const expectedHmac =
-      '9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2';
+      "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2";
 
     expect(ourHmac.toHex()).toBe(expectedHmac);
   });

--- a/docs/snippets/hmac-sha256/hmac-sha256.ts
+++ b/docs/snippets/hmac-sha256/hmac-sha256.ts
@@ -1,148 +1,141 @@
 // https://github.com/o1-labs-XT/hmac-sha256-o1js/blob/main/src/hmac-sha256.ts
 
-import {
-    Bytes,
-    Hash,
-    UInt32,
-    FlexibleBytes,
-    Provable,
-    UInt8,
-  } from 'o1js';
-  
+import { Bytes, Hash, UInt32, FlexibleBytes, Provable, UInt8 } from "o1js";
+
+/**
+ * Implementation of HMAC-SHA256 (Hash-based Message Authentication Code using SHA-256)
+ * Following the standard HMAC construction:
+ * HMAC(K,m) = H((k_0 ^ opad) || H((k_0 ^ ipad) || m))
+ * where:
+ * - k_0 is the input key (padded/hashed if necessary)
+ * - ipad is the inner padding (0x36 repeated)
+ * - opad is the outer padding (0x5c repeated)
+ * - H is SHA-256 hash function
+ * - || denotes concatenation
+ * - ^ denotes XOR operation
+ */
+export class HMAC_SHA256 {
+  static readonly IPAD = UInt32.from(0x36363636); // Inner padding constant
+  static readonly OPAD = UInt32.from(0x5c5c5c5c); // Outer padding constant
+  static readonly BLOCK_SIZE = 64; // Block size for SHA256 (512 bits / 64 bytes)
+
   /**
-   * Implementation of HMAC-SHA256 (Hash-based Message Authentication Code using SHA-256)
-   * Following the standard HMAC construction:
-   * HMAC(K,m) = H((k_0 ^ opad) || H((k_0 ^ ipad) || m))
-   * where:
-   * - k_0 is the input key (padded/hashed if necessary)
-   * - ipad is the inner padding (0x36 repeated)
-   * - opad is the outer padding (0x5c repeated)
-   * - H is SHA-256 hash function
-   * - || denotes concatenation
-   * - ^ denotes XOR operation
+   * Prepares a key for HMAC-SHA256 computation according to the HMAC specification (RFC 2104).
+   *
+   * If the key is longer than the block size (64 bytes):
+   * - The key is first hashed using SHA-256 to produce a 32-byte key
+   * - Then the 32-byte key is padded with zeros to reach the block size (64 bytes)
+   *
+   * If the key is shorter than the block size:
+   * - The key is padded with zeros to reach the block size
+   *
+   * If the key is exactly the block size:
+   * - The key is used as-is
+   *
+   * @param key - The input key as FlexibleBytes
+   * @returns A standardized key of exactly BLOCK_SIZE (64) bytes
    */
-  export class HMAC_SHA256 {
-    static readonly IPAD = UInt32.from(0x36363636); // Inner padding constant
-    static readonly OPAD = UInt32.from(0x5c5c5c5c); // Outer padding constant
-    static readonly BLOCK_SIZE = 64; // Block size for SHA256 (512 bits / 64 bytes)
-  
-    /**
-     * Prepares a key for HMAC-SHA256 computation according to the HMAC specification (RFC 2104).
-     *
-     * If the key is longer than the block size (64 bytes):
-     * - The key is first hashed using SHA-256 to produce a 32-byte key
-     * - Then the 32-byte key is padded with zeros to reach the block size (64 bytes)
-     *
-     * If the key is shorter than the block size:
-     * - The key is padded with zeros to reach the block size
-     *
-     * If the key is exactly the block size:
-     * - The key is used as-is
-     *
-     * @param key - The input key as FlexibleBytes
-     * @returns A standardized key of exactly BLOCK_SIZE (64) bytes
-     */
-    static prepareKey(key: FlexibleBytes): Bytes {
-      let keyBuffer = Bytes.from(key);
-  
-      if (key.length > this.BLOCK_SIZE) {
-        const hashedKeyBuffer = Hash.SHA2_256.hash(key);
-        keyBuffer = Bytes.from(hashedKeyBuffer);
-      }
-  
-      if (keyBuffer.length < this.BLOCK_SIZE) {
-        keyBuffer = Bytes(this.BLOCK_SIZE).from(keyBuffer.bytes);
-      }
-  
-      return keyBuffer;
+  static prepareKey(key: FlexibleBytes): Bytes {
+    let keyBuffer = Bytes.from(key);
+
+    if (key.length > this.BLOCK_SIZE) {
+      const hashedKeyBuffer = Hash.SHA2_256.hash(key);
+      keyBuffer = Bytes.from(hashedKeyBuffer);
     }
-  
-    /**
-     * Computes HMAC-SHA256 for given key and message
-     * @param key - The key for HMAC as FlexibleBytes
-     * @param message - The message to authenticate as FlexibleBytes
-     * @returns The HMAC hash as Bytes
-     */
-    static compute(key: FlexibleBytes, message: FlexibleBytes): Bytes {
-      // Step 1: k_0
-      const k0 = this.prepareKey(key);
-  
-      // Convert padded key to UInt32 array for XOR operations
-      const k0Uint32 = Provable.Array(UInt32, 16).empty();
-      const k0Bytes = Provable.Array(UInt8, this.BLOCK_SIZE).empty();
-  
-      // Copy the key bytes into a provable array
-      for (let i = 0; i < this.BLOCK_SIZE; i++) {
-        k0Bytes[i] = k0.bytes[i];
-      }
-  
-      // Construct each UInt32 from 4 bytes with proper byte ordering
-      for (let i = 0; i < 16; i++) {
-        k0Uint32[i] = UInt32.fromBytes([
-          k0Bytes[i * 4 + 3],
-          k0Bytes[i * 4 + 2],
-          k0Bytes[i * 4 + 1],
-          k0Bytes[i * 4 + 0],
-        ]);
-      }
-  
-      // Step 2: k_0 ^ ipad
-      const k0IpadXor = Provable.Array(UInt32, 16).empty();
-      for (let i = 0; i < 16; i++) {
-        k0IpadXor[i] = k0Uint32[i].xor(this.IPAD);
-      }
-  
-      // Step 3: (k_0 ^ ipad) || message
-      const k0IpadBytes = Provable.Array(UInt8, this.BLOCK_SIZE).empty();
-      for (let i = 0; i < 16; i++) {
-        const ipadBytes = k0IpadXor[i].toBytes();
-        k0IpadBytes[i * 4 + 0] = ipadBytes[3];
-        k0IpadBytes[i * 4 + 1] = ipadBytes[2];
-        k0IpadBytes[i * 4 + 2] = ipadBytes[1];
-        k0IpadBytes[i * 4 + 3] = ipadBytes[0];
-      }
-  
-      const messageBytes = Bytes.from(message).bytes;
-      const innerBlock = Provable.Array(
-        UInt8,
-        this.BLOCK_SIZE + messageBytes.length
-      ).empty();
-  
-      for (let i = 0; i < this.BLOCK_SIZE; i++) {
-        innerBlock[i] = k0IpadBytes[i];
-      }
-      for (let i = 0; i < messageBytes.length; i++) {
-        innerBlock[this.BLOCK_SIZE + i] = messageBytes[i];
-      }
-  
-      // Step 4: H((k_0 ^ ipad) || message)
-      const innerHash = Hash.SHA2_256.hash(innerBlock);
-  
-      // Step 5: k_0 ^ opad
-      const k0OpadXor = Provable.Array(UInt32, 16).empty();
-      for (let i = 0; i < 16; i++) {
-        k0OpadXor[i] = k0Uint32[i].xor(this.OPAD);
-      }
-  
-      // Step 6: (k_0 ^ opad) || H((k_0 ^ ipad) || message)
-      const k0OpadBytes = Provable.Array(UInt8, this.BLOCK_SIZE).empty();
-      for (let i = 0; i < 16; i++) {
-        const opadBytes = k0OpadXor[i].toBytes();
-        k0OpadBytes[i * 4 + 0] = opadBytes[3];
-        k0OpadBytes[i * 4 + 1] = opadBytes[2];
-        k0OpadBytes[i * 4 + 2] = opadBytes[1];
-        k0OpadBytes[i * 4 + 3] = opadBytes[0];
-      }
-  
-      const outerBlock = Provable.Array(UInt8, this.BLOCK_SIZE + 32).empty();
-      for (let i = 0; i < this.BLOCK_SIZE; i++) {
-        outerBlock[i] = k0OpadBytes[i];
-      }
-      for (let i = 0; i < 32; i++) {
-        outerBlock[this.BLOCK_SIZE + i] = innerHash.bytes[i];
-      }
-  
-      // Step 7: H((k_0 ^ opad) || H((k_0 ^ ipad) || message))
-      return Hash.SHA2_256.hash(outerBlock);
+
+    if (keyBuffer.length < this.BLOCK_SIZE) {
+      keyBuffer = Bytes(this.BLOCK_SIZE).from(keyBuffer.bytes);
     }
+
+    return keyBuffer;
   }
+
+  /**
+   * Computes HMAC-SHA256 for given key and message
+   * @param key - The key for HMAC as FlexibleBytes
+   * @param message - The message to authenticate as FlexibleBytes
+   * @returns The HMAC hash as Bytes
+   */
+  static compute(key: FlexibleBytes, message: FlexibleBytes): Bytes {
+    // Step 1: k_0
+    const k0 = this.prepareKey(key);
+
+    // Convert padded key to UInt32 array for XOR operations
+    const k0Uint32 = Provable.Array(UInt32, 16).empty();
+    const k0Bytes = Provable.Array(UInt8, this.BLOCK_SIZE).empty();
+
+    // Copy the key bytes into a provable array
+    for (let i = 0; i < this.BLOCK_SIZE; i++) {
+      k0Bytes[i] = k0.bytes[i];
+    }
+
+    // Construct each UInt32 from 4 bytes with proper byte ordering
+    for (let i = 0; i < 16; i++) {
+      k0Uint32[i] = UInt32.fromBytes([
+        k0Bytes[i * 4 + 3],
+        k0Bytes[i * 4 + 2],
+        k0Bytes[i * 4 + 1],
+        k0Bytes[i * 4 + 0],
+      ]);
+    }
+
+    // Step 2: k_0 ^ ipad
+    const k0IpadXor = Provable.Array(UInt32, 16).empty();
+    for (let i = 0; i < 16; i++) {
+      k0IpadXor[i] = k0Uint32[i].xor(this.IPAD);
+    }
+
+    // Step 3: (k_0 ^ ipad) || message
+    const k0IpadBytes = Provable.Array(UInt8, this.BLOCK_SIZE).empty();
+    for (let i = 0; i < 16; i++) {
+      const ipadBytes = k0IpadXor[i].toBytes();
+      k0IpadBytes[i * 4 + 0] = ipadBytes[3];
+      k0IpadBytes[i * 4 + 1] = ipadBytes[2];
+      k0IpadBytes[i * 4 + 2] = ipadBytes[1];
+      k0IpadBytes[i * 4 + 3] = ipadBytes[0];
+    }
+
+    const messageBytes = Bytes.from(message).bytes;
+    const innerBlock = Provable.Array(
+      UInt8,
+      this.BLOCK_SIZE + messageBytes.length
+    ).empty();
+
+    for (let i = 0; i < this.BLOCK_SIZE; i++) {
+      innerBlock[i] = k0IpadBytes[i];
+    }
+    for (let i = 0; i < messageBytes.length; i++) {
+      innerBlock[this.BLOCK_SIZE + i] = messageBytes[i];
+    }
+
+    // Step 4: H((k_0 ^ ipad) || message)
+    const innerHash = Hash.SHA2_256.hash(innerBlock);
+
+    // Step 5: k_0 ^ opad
+    const k0OpadXor = Provable.Array(UInt32, 16).empty();
+    for (let i = 0; i < 16; i++) {
+      k0OpadXor[i] = k0Uint32[i].xor(this.OPAD);
+    }
+
+    // Step 6: (k_0 ^ opad) || H((k_0 ^ ipad) || message)
+    const k0OpadBytes = Provable.Array(UInt8, this.BLOCK_SIZE).empty();
+    for (let i = 0; i < 16; i++) {
+      const opadBytes = k0OpadXor[i].toBytes();
+      k0OpadBytes[i * 4 + 0] = opadBytes[3];
+      k0OpadBytes[i * 4 + 1] = opadBytes[2];
+      k0OpadBytes[i * 4 + 2] = opadBytes[1];
+      k0OpadBytes[i * 4 + 3] = opadBytes[0];
+    }
+
+    const outerBlock = Provable.Array(UInt8, this.BLOCK_SIZE + 32).empty();
+    for (let i = 0; i < this.BLOCK_SIZE; i++) {
+      outerBlock[i] = k0OpadBytes[i];
+    }
+    for (let i = 0; i < 32; i++) {
+      outerBlock[this.BLOCK_SIZE + i] = innerHash.bytes[i];
+    }
+
+    // Step 7: H((k_0 ^ opad) || H((k_0 ^ ipad) || message))
+    return Hash.SHA2_256.hash(outerBlock);
+  }
+}


### PR DESCRIPTION
- Added the hmac-sha256 zkProgram from the Exploration Team repo:
[src/hmac-sha256.ts](https://github.com/o1-labs-XT/hmac-sha256-o1js/blob/main/src/hmac-sha256.ts)

- Migrated tests from the same repo:
[src/hmac-sha256.test.ts](https://github.com/o1-labs-XT/hmac-sha256-o1js/blob/main/src/hmac-sha256.test.ts)
    • Converted the test suite from Jest to Vitest to ensure compatibility with the documentation site.
    • Removed randomized tests — only RFC test vectors are retained for better performance.

Checklist
 [ x ] Build is passing
 [ x ] Tests are passing

